### PR TITLE
Fix: Chmod media files to 777 for nginx to work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - frontend_vol:/mnt/frontend/:ro
-      - media_vol:/mnt/media/:ro
+      - media_vol:/mnt/media/ # TODO nginx doesn't work with readonly (644 permission) files for only this volume!
       - backend_statics_vol:/mnt/backend-statics/:ro
       - $FULLCHAIN_PATH:/etc/ssl-files/fullchain.pem:ro
       - $PRIVKEY_PATH:/etc/ssl-files/privkey.pem:ro

--- a/static-data-provider/Dockerfile
+++ b/static-data-provider/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:3.12.1
 WORKDIR /static-data-provider/
 ADD "https://www.dropbox.com/sh/wb7wit4rtiyaqto/AADoJ3zkDF_dS0mv1fGUh7tta?dl=1" media.zip
 RUN mkdir media/ && unzip media.zip -d media/ && chmod -x -R media/ && rm media.zip
-CMD cp -rf /static-data-provider/media/* /mnt/media/ && echo "Media files updated in: /mnt/media/"
+CMD cp -rf /static-data-provider/media/* /mnt/media/ && chmod 777 -R /mnt/media/ && echo "Media files updated in: /mnt/media/"


### PR DESCRIPTION
Surprisingly nginx can't serve media files when they're readonly!