### PR TITLE
Fix: Use pure shell instead of docker_compose module

### DIFF
--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -69,11 +69,9 @@
         dest: '{{ dest_root_dir }}/.env'
 
     - name: 'Pull images'
-      docker_compose:
-        project_src: '{{ dest_root_dir }}'
-        build: no
-        pull: yes
-        state: present
+      shell: 'cd {{ dest_root_dir }} && docker-compose pull'
+      # The builtin docker_compose module sometimes hangs on pulling!
+      # See https://github.com/Winter-Seminar-Series/WSS-site/issues/192 for more details.
 
     - name: 'Stop containers'
       docker_compose:


### PR DESCRIPTION
Use pure shell instead of docker_compose module on ansible deployment
docker pull phase.

Closes #192